### PR TITLE
MSVC do not need manually add libmath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,9 @@ add_library(Cello::Cello ALIAS Cello)
 target_include_directories(Cello PUBLIC include)
 
 target_link_libraries(Cello PRIVATE Threads::Threads)
-target_link_libraries(Cello PRIVATE m)
+if(NOT MSVC)
+        target_link_libraries(Cello PRIVATE m)
+endif()
 
 ###############################################################################
 # Build Cello Tests


### PR DESCRIPTION
I find that building will be fail if examples and tests are built, because `libm` do not need to add explicitly.